### PR TITLE
Fix debug.browser when first line has no data nodes associated

### DIFF
--- a/R/debugBrowser.R
+++ b/R/debugBrowser.R
@@ -279,6 +279,9 @@ debug.browser <- function() {
     # when state is true, but their script nubmer is NA, that's how it is 
     # possible to tell pre-execution variables
     pre.data.nodes <- debug.from.line(pos.lines[1], state = T)[[1]]
+    if(is.atomic(pre.data.nodes)) {
+      pre.data.nodes <- as.data.frame(pre.data.nodes)
+    }
     pre.data.nodes <- pre.data.nodes[is.na(pre.data.nodes$script), ]
     .load.variables(pre.data.nodes, var.env)
   } else {

--- a/R/debugBrowser.R
+++ b/R/debugBrowser.R
@@ -73,18 +73,21 @@ debug.browser <- function() {
             "\n",
             sep=""))
   
-
   # Loads variables that may have been present before the script started into 
   # the recontructed environment
   pre.data.nodes <- debug.from.line(pos.lines[1], state = T)[[1]]
+  if(as.vector(pre.data.nodes)) {
+    pre.data.nodes <- as.list(pre.data.nodes)
+  }
   pre.data.nodes <- pre.data.nodes[is.na(pre.data.nodes$script), ]
+  
   if(nrow(pre.data.nodes) > 0) {
     .load.variables(pre.data.nodes, var.env)
   } else {
     var.env$vars <- NA
   }
-  
-  
+
+    
   # This loop is the "interactive console" of the program
   # it will repeatedly prompt for an input until the user quits
   # It operates similarly to the R browser() function
@@ -96,7 +99,7 @@ debug.browser <- function() {
       print("Quitting")
       break
     # lists variables present in "execution"
-    # THey can enter one as an input and it will print it's value
+    # They can enter one as an input and it will print it's value
     } else if(input == "ls") { 
       print(var.env$vars)
       

--- a/R/debugBrowser.R
+++ b/R/debugBrowser.R
@@ -76,9 +76,11 @@ debug.browser <- function() {
   # Loads variables that may have been present before the script started into 
   # the recontructed environment
   pre.data.nodes <- debug.from.line(pos.lines[1], state = T)[[1]]
-  if(as.vector(pre.data.nodes)) {
-    pre.data.nodes <- as.list(pre.data.nodes)
+  
+  if(is.atomic(pre.data.nodes)) {
+    pre.data.nodes <- as.data.frame(pre.data.nodes)
   }
+  
   pre.data.nodes <- pre.data.nodes[is.na(pre.data.nodes$script), ]
   
   if(nrow(pre.data.nodes) > 0) {

--- a/R/debugFromLine.R
+++ b/R/debugFromLine.R
@@ -93,16 +93,12 @@ debug.from.line <- function(..., state = F, script.num = 1) {
   if (length(args) == 0) {
     print("State of all variables at end of execution:")
     ret.val <- .grab.line(max(pos.line), state = T, script.num = 1)
+    return(ret.val)
   } else {
     ret.val <- lapply(args, .grab.line, state, script.num)
     names(ret.val) <- args
+    return(ret.val)
   }
-  
-  # ensure type of returned value is a list
-  if(is.vector(ret.val)) {
-    return(as.list(ret.val))
-  }
-  return(ret.val)
 }
 
 #' This helper function is used to find all procedure or data nodes

--- a/R/debugFromLine.R
+++ b/R/debugFromLine.R
@@ -93,12 +93,16 @@ debug.from.line <- function(..., state = F, script.num = 1) {
   if (length(args) == 0) {
     print("State of all variables at end of execution:")
     ret.val <- .grab.line(max(pos.line), state = T, script.num = 1)
-    return(ret.val)
   } else {
     ret.val <- lapply(args, .grab.line, state, script.num)
     names(ret.val) <- args
-    return(ret.val)
   }
+  
+  # ensure type of returned value is a list
+  if(is.vector(ret.val)) {
+    return(as.list(ret.val))
+  }
+  return(ret.val)
 }
 
 #' This helper function is used to find all procedure or data nodes

--- a/tests/testthat/test-line.R
+++ b/tests/testthat/test-line.R
@@ -69,5 +69,8 @@ debug.init(test.data)
 test_that("no data nodes associated with line", {
   line.results <- debug.from.line(1, state = T)
   expect_equal(typeof(line.results) == "list")
-  expect_equivalent(line.results, as.list(rep("NA", 6)))
+  
+  expected <- as.list(rep(NA, 6)))
+  names(expected) <- c("var/code", "val", "container" "dim", "type", "script")
+  expect_equal(line.results, expected)
 })

--- a/tests/testthat/test-line.R
+++ b/tests/testthat/test-line.R
@@ -62,15 +62,3 @@ test_that("error output works", {
   expect_equal(length(line.results), 1)
   expect_equal(nrow(line.results[[1]]), 6)
 })
-
-test.data <- system.file("testdata", "stepin3.json", package = "provDebugR")
-debug.init(test.data)
-
-test_that("no data nodes associated with line", {
-  line.results <- debug.from.line(1, state = T)
-  expect_equal(typeof(line.results) == "list")
-  
-  expected <- as.list(rep(NA, 6))
-  names(expected) <- c("var/code", "val", "container", "dim", "type", "script")
-  expect_equal(line.results, expected)
-})

--- a/tests/testthat/test-line.R
+++ b/tests/testthat/test-line.R
@@ -62,3 +62,19 @@ test_that("error output works", {
   expect_equal(length(line.results), 1)
   expect_equal(nrow(line.results[[1]]), 6)
 })
+
+# case when called from debug.browser
+# and when the first line has no data nodes associated
+test.data <- system.file("testdata", "stepin3.json", package = "provDebugR")
+debug.init(test.data)
+
+test_that("when called from debug.browser", {
+  line.results <- debug.from.line(1, state = T)[[1]]
+  
+  # test dimensions and type
+  expect_true(is.matrix(line.results))
+  expect_equal(dim(line.results), c(1,6))
+  
+  # test content
+  expect_equivalent(as.vector(line.results), rep(NA, 6))
+})

--- a/tests/testthat/test-line.R
+++ b/tests/testthat/test-line.R
@@ -62,3 +62,12 @@ test_that("error output works", {
   expect_equal(length(line.results), 1)
   expect_equal(nrow(line.results[[1]]), 6)
 })
+
+test.data <- system.file("testdata", "stepin3.json", package = "provDebugR")
+debug.init(test.data)
+
+test_that("no data nodes associated with line", {
+  line.results <- debug.from.line(1, state = T)
+  expect_equal(typeof(line.results) == "list")
+  expect_equivalent(line.results, as.list(rep("NA", 6)))
+})

--- a/tests/testthat/test-line.R
+++ b/tests/testthat/test-line.R
@@ -71,6 +71,6 @@ test_that("no data nodes associated with line", {
   expect_equal(typeof(line.results) == "list")
   
   expected <- as.list(rep(NA, 6))
-  names(expected) <- c("var/code", "val", "container" "dim", "type", "script")
+  names(expected) <- c("var/code", "val", "container", "dim", "type", "script")
   expect_equal(line.results, expected)
 })

--- a/tests/testthat/test-line.R
+++ b/tests/testthat/test-line.R
@@ -70,7 +70,7 @@ test_that("no data nodes associated with line", {
   line.results <- debug.from.line(1, state = T)
   expect_equal(typeof(line.results) == "list")
   
-  expected <- as.list(rep(NA, 6)))
+  expected <- as.list(rep(NA, 6))
   names(expected) <- c("var/code", "val", "container" "dim", "type", "script")
   expect_equal(line.results, expected)
 })


### PR DESCRIPTION
`debugBrowser`

* Fixed case where the first line has no data nodes associated with it.