### PR TITLE
Fix the Stack Overflow error (fixes #73)

### DIFF
--- a/R/debugExceptions.R
+++ b/R/debugExceptions.R
@@ -246,7 +246,7 @@ debug.error <- function(stack.overflow = FALSE)
 	# typically have an unneeded prefix followed
 	# by a colon ":"
 	if(length(split) > 1) {
-		error.message <- split[-1]
+		error.message <- split[2]
 	}
 
 	# This complicated mess of regex i=actually checks for 4 things (all inclusive):

--- a/R/debugExceptions.R
+++ b/R/debugExceptions.R
@@ -242,9 +242,10 @@ debug.error <- function(stack.overflow = FALSE)
 {
 	split <- strsplit(error.message, ":")[[1]]
 
-	# Error messages from the prov.json will
-	# typically have an unneeded prefix followed
-	# by a colon ":"
+	# Error messages from the prov.json will typically have
+	# an unneeded prefix followed by a colon ":".
+	# e.g. "Error in data.frame(cylinders, mpg) :
+	#         arguments imply differing number of rows: 4, 3"
 	if(length(split) > 1) {
 		error.message <- split[2]
 	}

--- a/R/debugExceptions.R
+++ b/R/debugExceptions.R
@@ -212,8 +212,8 @@ debug.error <- function(stack.overflow = FALSE)
 	# user is choosing
 	path <- paste("/2.2/search?order=", order,
 				  "&sort=", sort,
-				  "&tagged=", tagged, "
-				  &intitle=", search.query,
+				  "&tagged=", tagged, 
+				  "&intitle=", search.query,
 				  "&site=stackoverflow",
 				  sep ="")
 

--- a/R/debugExceptions.R
+++ b/R/debugExceptions.R
@@ -243,7 +243,7 @@ debug.error <- function(stack.overflow = FALSE)
 	split <- strsplit(error.message, ":")[[1]]
 
 	# Error messages from the prov.json will
-	# typically have an uneeded prefix followed
+	# typically have an unneeded prefix followed
 	# by a colon ":"
 	if(length(split) > 1) {
 		error.message <- split[-1]


### PR DESCRIPTION
This revision includes:
- Moving the opening `"` to the front of `&intitle="`
- Adding an example of `error.message` to the inline comment inside `.process.error`
- Changing `split[-1]` to `split[2]` to correctly remove the unneeded prefix